### PR TITLE
Add task form fix for Safari

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -122,6 +122,14 @@ div.Tokenize ul.TokensContainer {
   display: -ms-flexbox;
   display: flex;
   flex-flow: wrap;
+  justify-content: flex-start;
+  align-items: start;
+  &::before, &::after {
+    display: none;
+  }
+  & > * {
+    float: none;
+  }
 }
 .sticky-record {
   position: sticky;

--- a/app/assets/stylesheets/application/_new-entry.scss
+++ b/app/assets/stylesheets/application/_new-entry.scss
@@ -13,8 +13,12 @@
   .card > .row {
     display: flex;
     flex-flow: row wrap;
+    &::before, &::after {
+      display: none;
+    }
     align-items: center;
     > div {
+      float: none;
       @media #{$max-sm} {
         width: 100%;
       }

--- a/app/assets/stylesheets/application/_new-entry.scss
+++ b/app/assets/stylesheets/application/_new-entry.scss
@@ -30,9 +30,10 @@
   }
   .easter {
     display: block;
+    width: auto;
+    max-height: 200px;
     max-width: 100%;
-    height: auto;
-    margin: 0 auto -12px;
+    margin: 0 auto;
   }
   .form-control {
     border: none;

--- a/app/assets/stylesheets/application/_project-card.scss
+++ b/app/assets/stylesheets/application/_project-card.scss
@@ -1,3 +1,6 @@
+.projects-cards {
+  align-items: stretch !important;
+}
 .project-card {
   margin-bottom: 30px;
   .card {

--- a/app/javascript/components/time_table/projects/project_stats.js
+++ b/app/javascript/components/time_table/projects/project_stats.js
@@ -20,7 +20,7 @@ class ProjectStats extends React.Component {
     const data = stats[0];
 
     return (
-      <div className="col-lg-4 card-container project-card">
+      <div className="col-xs-12 col-sm-6 col-lg-4 card-container project-card">
         <div className="card h-100">
           <h3 className="title">
             {this.projectLabel()}


### PR DESCRIPTION
Wrapping of add task form works now on Safari and iPads.

`::before` element from bootstrap3 caused a column to wrap too early. 

Additionally
- projects looks better on iPads
- lunch gifs have same heights