### PR TITLE
Bring back recounting periods async functionality

### DIFF
--- a/lib/accounting_periods_manager.rb
+++ b/lib/accounting_periods_manager.rb
@@ -32,6 +32,6 @@ class AccountingPeriodsManager
   end
 
   def worker_params
-    { user_id: @user_id }
+    { user_id: @user_id.to_s }
   end
 end

--- a/spec/lib/accounting_periods_manager_spec.rb
+++ b/spec/lib/accounting_periods_manager_spec.rb
@@ -8,19 +8,19 @@ describe AccountingPeriodsManager do
   let(:check_job_exist) { double('check_job_exist') }
 
   it 'add job because there is no same job in queue' do
-    expect(CheckJobExist).to receive(:new).with(RecountAccountingPeriodsWorker, user_id: user.id).and_return(check_job_exist)
+    expect(CheckJobExist).to receive(:new).with(RecountAccountingPeriodsWorker, user_id: user.id.to_s).and_return(check_job_exist)
     expect(check_job_exist).to receive(:call).and_return(false)
     expect(check_job_exist).to receive(:jid).and_return('26w')
 
     manager = AccountingPeriodsManager.new(user_id: user.id)
-    expect(RecountAccountingPeriodsWorker).to receive(:perform_async).with(user_id: user.id)
+    expect(RecountAccountingPeriodsWorker).to receive(:perform_async).with(user_id: user.id.to_s)
 
     manager.perform_async_once
     expect(manager.job_jid).to eq('26w')
   end
 
   it 'do not add job because there is same job in queue' do
-    expect(CheckJobExist).to receive(:new).with(RecountAccountingPeriodsWorker, user_id: user.id).and_return(check_job_exist)
+    expect(CheckJobExist).to receive(:new).with(RecountAccountingPeriodsWorker, user_id: user.id.to_s).and_return(check_job_exist)
     expect(check_job_exist).to receive(:call).and_return(true)
     expect(check_job_exist).to receive(:jid).twice.and_return('26w')
 


### PR DESCRIPTION
Bring back the functionality of 'Recount periods' button in '/accounting_periods' view. Check by interval whether the counting has been completed. Until it does, disable button to prevent from creating unnecessary workers in sidekick's queue